### PR TITLE
Feature/comment approval

### DIFF
--- a/assets/js/launch-comments.ts
+++ b/assets/js/launch-comments.ts
@@ -1,6 +1,6 @@
 import { html, LitElement, css } from 'lit'
 import { customElement, property, query, state } from 'lit/decorators.js'
-import { liveState, liveStateConfig } from 'phx-live-state';
+import { liveState, liveStateConfig, liveStateProperty } from 'phx-live-state';
 
 type Comment = {
   author: string;
@@ -37,6 +37,10 @@ export class LaunchCommentsElement extends LitElement {
 
   @liveStateConfig('params.url')
   get pageUrl() { return window.location.href; }
+
+  @state()
+  @liveStateProperty('/requires_approval')
+  approvalRequired: boolean = false;
 
   @query('input[name="author"]')
   author: HTMLInputElement | undefined;
@@ -91,6 +95,7 @@ export class LaunchCommentsElement extends LitElement {
         `)}
       </div>
       <div part="new-comment">
+        ${this.approvalRequired ? html`<slot name="approval-notice"><div>Your comments will appear after approval by the moderator</div></slog>` : ``}
         <form part="form" @submit=${this.addComment}>
           <div part="comment-field-author">
             <label part="author-label" for="author">Author</label>

--- a/lib/factory.ex
+++ b/lib/factory.ex
@@ -100,6 +100,7 @@ defmodule LaunchCart.Factory do
       comment_site: build(:comment_site),
       author: Person.name,
       url: Internet.url(),
+      approved: true,
       comment: "I think therefore I am"
     }
   end

--- a/lib/launch_cart/comment_sites/comment_site.ex
+++ b/lib/launch_cart/comment_sites/comment_site.ex
@@ -9,6 +9,7 @@ defmodule LaunchCart.CommentSites.CommentSite do
   schema "comment_sites" do
     field :name, :string
     field :url, :string
+    field :requires_approval, :boolean, default: false
     belongs_to :user, User
     has_many :comments, Comment
 
@@ -18,7 +19,7 @@ defmodule LaunchCart.CommentSites.CommentSite do
   @doc false
   def changeset(comment_site, attrs) do
     comment_site
-    |> cast(attrs, [:name, :url, :user_id])
+    |> cast(attrs, [:name, :url, :user_id, :requires_approval])
     |> validate_required([:name, :url])
   end
 end

--- a/lib/launch_cart/comments.ex
+++ b/lib/launch_cart/comments.ex
@@ -4,6 +4,8 @@ defmodule LaunchCart.Comments do
   """
 
   import Ecto.Query, warn: false
+  alias LaunchCart.CommentSites
+  alias LaunchCart.CommentSites.CommentSite
   alias LaunchCart.Repo
 
   alias LaunchCart.Comments.{Comment, CommentEmail}
@@ -21,8 +23,7 @@ defmodule LaunchCart.Comments do
   """
   def list_comments(site_id, url) do
     from(c in Comment,
-      where: c.comment_site_id == ^site_id,
-      where: c.url == ^url,
+      where: c.comment_site_id == ^site_id and c.url == ^url and c.approved == true,
       order_by: {:desc, c.inserted_at}
     )
     |> Repo.all()
@@ -58,7 +59,7 @@ defmodule LaunchCart.Comments do
   """
   def create_comment(attrs \\ %{}) do
     %Comment{}
-    |> Comment.changeset(attrs)
+    |> Comment.changeset(attrs |> maybe_approve_comment())
     |> Repo.insert()
     |> case do
       {:ok, comment} ->
@@ -92,6 +93,18 @@ defmodule LaunchCart.Comments do
     comment
     |> Comment.changeset(attrs)
     |> Repo.update()
+    |> case do
+      {:ok, comment} ->
+        Phoenix.PubSub.broadcast(
+          LaunchCart.PubSub,
+          "comments:#{comment.comment_site_id}",
+          {:comment_updated, comment}
+        )
+        {:ok, comment}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   @doc """
@@ -121,5 +134,20 @@ defmodule LaunchCart.Comments do
   """
   def change_comment(%Comment{} = comment, attrs \\ %{}) do
     Comment.changeset(comment, attrs)
+  end
+
+  defp maybe_approve_comment(%{"comment_site_id" => comment_site_id} = attrs),
+    do: Map.put(attrs, "approved", approved?(comment_site_id))
+
+  defp maybe_approve_comment(%{comment_site_id: comment_site_id} = attrs),
+    do: Map.put(attrs, :approved, approved?(comment_site_id))
+
+  defp maybe_approve_comment(attrs), do: attrs
+
+  defp approved?(comment_site_id) do
+    case CommentSites.get_comment_site!(comment_site_id) do
+      %CommentSite{requires_approval: false} -> true
+      _ -> false
+    end
   end
 end

--- a/lib/launch_cart/comments.ex
+++ b/lib/launch_cart/comments.ex
@@ -29,6 +29,14 @@ defmodule LaunchCart.Comments do
     |> Repo.all()
   end
 
+  def list_comments(site_id) do
+    from(c in Comment,
+      where: c.comment_site_id == ^site_id,
+      order_by: {:desc, c.inserted_at}
+    )
+    |> Repo.all()
+  end
+
   @doc """
   Gets a single comment.
 

--- a/lib/launch_cart/comments/comment.ex
+++ b/lib/launch_cart/comments/comment.ex
@@ -12,6 +12,7 @@ defmodule LaunchCart.Comments.Comment do
     field :author, :string
     field :comment, :string
     field :url, :string
+    field :approved, :boolean, default: false
     belongs_to :comment_site, CommentSite
 
     timestamps()
@@ -20,7 +21,7 @@ defmodule LaunchCart.Comments.Comment do
   @doc false
   def changeset(comment, attrs) do
     comment
-    |> cast(attrs, [:author, :comment, :url, :comment_site_id])
-    |> validate_required([:author, :comment, :url])
+    |> cast(attrs, [:author, :comment, :url, :comment_site_id, :approved])
+    |> validate_required([:author, :comment, :url, :comment_site_id])
   end
 end

--- a/lib/launch_cart_web/channels/comments_channel.ex
+++ b/lib/launch_cart_web/channels/comments_channel.ex
@@ -19,16 +19,20 @@ defmodule LaunchCartWeb.CommentsChannel do
   end
 
   @impl true
-  def handle_event("add_comment", comment_params, %{comments: comments} = state) do
+  def handle_event("add_comment", comment_params, state) do
     case Comments.create_comment(comment_params) do
-      {:ok, comment} ->
-        new_state = Map.put(state, :comments, comments ++ [comment])
-        {:reply, [%Event{name: "comment_added", detail: comment}], new_state}
+      {:ok, comment} -> {:reply, [%Event{name: "comment_added", detail: comment}], state}
     end
   end
 
   @impl true
   def handle_message({:comment_created, comment}, %{url: url} = state) do
+    {:noreply,
+     state |> Map.put(:comments, Comments.list_comments(comment.comment_site_id, url))}
+  end
+
+  @impl true
+  def handle_message({:comment_updated, comment}, %{url: url} = state) do
     {:noreply,
      state |> Map.put(:comments, Comments.list_comments(comment.comment_site_id, url))}
   end

--- a/lib/launch_cart_web/channels/comments_channel.ex
+++ b/lib/launch_cart_web/channels/comments_channel.ex
@@ -2,6 +2,8 @@ defmodule LaunchCartWeb.CommentsChannel do
   use LiveState.Channel, web_module: LaunchCartWeb
 
   alias LaunchCart.Comments
+  alias LaunchCart.CommentSites
+  alias LaunchCart.CommentSites.CommentSite
   alias LiveState.Event
 
   @impl true
@@ -12,9 +14,12 @@ defmodule LaunchCartWeb.CommentsChannel do
   def init("launch_comments:" <> comment_site_id, %{"url" => url}, _socket) do
     Phoenix.PubSub.subscribe(LaunchCart.PubSub, "comments:#{comment_site_id}")
 
-    case Comments.list_comments(comment_site_id, url) do
+    with %CommentSite{requires_approval: requires_approval} <-
+           CommentSites.get_comment_site!(comment_site_id),
+         comments <- Comments.list_comments(comment_site_id, url) do
+      {:ok, %{comments: comments, url: url, requires_approval: requires_approval} }
+    else
       nil -> {:error, "Comment site not found"}
-      comments -> {:ok, %{comments: comments, url: url}}
     end
   end
 
@@ -27,14 +32,12 @@ defmodule LaunchCartWeb.CommentsChannel do
 
   @impl true
   def handle_message({:comment_created, comment}, %{url: url} = state) do
-    {:noreply,
-     state |> Map.put(:comments, Comments.list_comments(comment.comment_site_id, url))}
+    {:noreply, state |> Map.put(:comments, Comments.list_comments(comment.comment_site_id, url))}
   end
 
   @impl true
   def handle_message({:comment_updated, comment}, %{url: url} = state) do
-    {:noreply,
-     state |> Map.put(:comments, Comments.list_comments(comment.comment_site_id, url))}
+    {:noreply, state |> Map.put(:comments, Comments.list_comments(comment.comment_site_id, url))}
   end
 
   @impl true

--- a/lib/launch_cart_web/live/comment_site_live/comments.ex
+++ b/lib/launch_cart_web/live/comment_site_live/comments.ex
@@ -1,0 +1,24 @@
+defmodule LaunchCartWeb.CommentSiteLive.Comments do
+  use LaunchCartWeb, :live_view
+
+  alias LaunchCart.CommentSites
+  alias LaunchCart.Comments
+
+  @impl true
+  def mount(_params, _session, %{assigns: %{current_user: user}} = socket) do
+    {:ok, assign(socket, :comment_sites, CommentSites.list_comment_sites(user))}
+  end
+
+  @impl true
+  def handle_params(%{"id" => comment_site_id}, _url, socket) do
+    {:noreply, socket |> assign(:comments, Comments.list_comments(comment_site_id))}
+  end
+
+  @impl true
+  def handle_event("approve_comment", %{"comment_id" => comment_id}, socket) do
+    with comment <- Comments.get_comment!(comment_id),
+         {:ok, _comment} <- Comments.update_comment(comment, %{approved: !comment.approved}) do
+      {:noreply, socket}
+    end
+  end
+end

--- a/lib/launch_cart_web/live/comment_site_live/comments.html.heex
+++ b/lib/launch_cart_web/live/comment_site_live/comments.html.heex
@@ -3,7 +3,7 @@
     <tr>
       <th>Author</th>
       <th>Comment</th>
-      <th>?</th>
+      <th>Approved?</th>
     </tr>
   </thead>
   <tbody id="comment_sites">

--- a/lib/launch_cart_web/live/comment_site_live/comments.html.heex
+++ b/lib/launch_cart_web/live/comment_site_live/comments.html.heex
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th>Author</th>
+      <th>Comment</th>
+      <th>?</th>
+    </tr>
+  </thead>
+  <tbody id="comment_sites">
+    <%= for comment <- @comments do %>
+      <tr id={"comment-#{comment.id}"}>
+        <td><%= comment.author %></td>
+        <td><%= comment.comment %></td>
+        <td><input type="checkbox" checked={comment.approved} id={"approve-comment-#{comment.id}"} phx-click="approve_comment" phx-value-comment_id={comment.id} /></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/lib/launch_cart_web/live/comment_site_live/form_component.html.heex
+++ b/lib/launch_cart_web/live/comment_site_live/form_component.html.heex
@@ -20,7 +20,13 @@
       <%= error_tag f, :url %>
       <%= text_input f, :url %>
     </div>
-    
+
+    <div class="input-group">
+      <%= label f, :requires_approval %>
+      <%= error_tag f, :requires_approval %>
+      <%= checkbox f, :requires_approval %>
+    </div>
+
     <div class="form__actions">
       <%= submit "Save", phx_disable_with: "Saving..." %>
     </div>

--- a/lib/launch_cart_web/live/comment_site_live/show.ex
+++ b/lib/launch_cart_web/live/comment_site_live/show.ex
@@ -5,7 +5,8 @@ defmodule LaunchCartWeb.CommentSiteLive.Show do
   alias LaunchCartWeb.Endpoint
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
+    IO.inspect(params)
     {:ok, socket}
   end
 

--- a/lib/launch_cart_web/live/comment_site_live/show.html.heex
+++ b/lib/launch_cart_web/live/comment_site_live/show.html.heex
@@ -1,15 +1,15 @@
 <h1>Adding comments to your website</h1>
 
 <%= if @live_action in [:edit] do %>
-  <.modal return_to={Routes.form_show_path(@socket, :show, @comment_site)}>
+  <.modal return_to={Routes.comment_site_show_path(@socket, :show, @comment_site)}>
     <.live_component
-      module={LaunchCartWeb.FormLive.FormComponent}
+      module={LaunchCartWeb.CommentSiteLive.FormComponent}
       id={@comment_site.id}
       title={@page_title}
       action={@live_action}
       user_id={@current_user.id}
-      form={@comment_site}
-      return_to={Routes.form_show_path(@socket, :show, @comment_site)}
+      comment_site={@comment_site}
+      return_to={Routes.comment_site_show_path(@socket, :show, @comment_site)}
     />
   </.modal>
 <% end %>
@@ -25,8 +25,11 @@
     <dd><%= @comment_site.id %></dd>
     <dt>URL:</dt>
     <dd><%= @url %></dd>
+    <dt>Comments Require Approval:</dt>
+    <dd><%= @comment_site.requires_approval %></dd>
 </dl>
 
+<.link navigate={Routes.comment_site_comments_path(@socket, :index, @comment_site)}>View Comments</.link>
 <h2 class="u-push__top--xl">Usage:</h2>
 <p>Using Launch Comments is easy! </p>
 <ol id="include-instructions" phx-hook="Prism">
@@ -48,7 +51,7 @@
 
 <div>
   <span>
-    <%= live_patch("Edit", to: Routes.form_show_path(@socket, :edit, @comment_site), class: "button") %>
+    <%= live_patch("Edit", to: Routes.comment_site_show_path(@socket, :edit, @comment_site), class: "button") %>
   </span>
-  | <span><%= live_redirect "Back", to: Routes.form_index_path(@socket, :index) %></span>
+  | <span><%= live_redirect "Back", to: Routes.comment_site_index_path(@socket, :index) %></span>
 </div>

--- a/lib/launch_cart_web/router.ex
+++ b/lib/launch_cart_web/router.ex
@@ -125,6 +125,7 @@ defmodule LaunchCartWeb.Router do
 
       live "/comment_sites/:id", CommentSiteLive.Show, :show
       live "/comment_sites/:id/show/edit", CommentSiteLive.Show, :edit
+      live "/comment_sites/:id/comments", CommentSiteLive.Comments, :index
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,6 @@ defmodule LaunchCart.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:httpoison, ">= 0.0.0"},
       {:live_elements, ">= 0.0.0"},
-      {:cors_plug, ">= 0.0.0"},
       {:wallaby, "~> 0.30.2",
        git: "https://github.com/launchscout/wallaby.git",
        branch: "shadow-dom",

--- a/priv/repo/migrations/20230927152710_add_approval_for_comments.exs
+++ b/priv/repo/migrations/20230927152710_add_approval_for_comments.exs
@@ -1,0 +1,13 @@
+defmodule LaunchCart.Repo.Migrations.AddApprovalForComments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:comment_sites) do
+      add :requires_approval, :boolean, default: false
+    end
+
+    alter table(:comments) do
+      add :approved, :boolean
+    end
+  end
+end

--- a/test/launch_cart/comments_test.exs
+++ b/test/launch_cart/comments_test.exs
@@ -3,27 +3,42 @@ defmodule LaunchCart.CommentsTest do
 
   alias LaunchCart.Comments
 
-  describe "comments" do
-    alias LaunchCart.Comments.Comment
+  alias LaunchCart.Comments.Comment
 
-    import LaunchCart.Factory
+  import LaunchCart.Factory
 
-    @invalid_attrs %{author: nil, comment: nil, url: nil}
+  @invalid_attrs %{author: nil, comment: nil, url: nil}
 
-    test "list_comments/1 returns all comments for site" do
-      comment = insert(:comment)
+  test "list_comments/1 returns all approved comments for site" do
+    comment_site = insert(:comment_site, requires_approval: true)
 
-      assert Comments.list_comments(comment.comment_site_id, comment.url) |> Enum.map(& &1.id) ==
-               [comment.id]
+    comment = insert(:comment, approved: true, comment_site: comment_site, url: "http://foo.bar")
+
+    unapproved_comment =
+      insert(:comment, approved: false, comment_site: comment_site, url: "http://foo.bar")
+
+    assert Comments.list_comments(comment_site.id, comment.url) |> Enum.map(& &1.id) ==
+             [comment.id]
+  end
+
+  test "get_comment!/1 returns the comment with given id" do
+    comment = insert(:comment)
+    assert Comments.get_comment!(comment.id)
+  end
+
+  describe "create_comment" do
+    setup do
+      comment_site = insert(:comment_site)
+      {:ok, %{comment_site: comment_site}}
     end
 
-    test "get_comment!/1 returns the comment with given id" do
-      comment = insert(:comment)
-      assert Comments.get_comment!(comment.id)
-    end
-
-    test "create_comment/1 with valid data creates a comment" do
-      valid_attrs = %{author: "some author", comment: "some comment", url: "some url"}
+    test "create_comment/1 with valid data creates a comment", %{comment_site: comment_site} do
+      valid_attrs = %{
+        author: "some author",
+        comment_site_id: comment_site.id,
+        comment: "some comment",
+        url: "some url"
+      }
 
       assert {:ok, %Comment{} = comment} = Comments.create_comment(valid_attrs)
       assert comment.author == "some author"
@@ -35,35 +50,39 @@ defmodule LaunchCart.CommentsTest do
       assert {:error, %Ecto.Changeset{}} = Comments.create_comment(@invalid_attrs)
     end
 
-    test "update_comment/2 with valid data updates the comment" do
-      comment = insert(:comment)
-
-      update_attrs = %{
-        author: "some updated author",
-        comment: "some updated comment",
-        url: "some updated url"
-      }
-
-      assert {:ok, %Comment{} = comment} = Comments.update_comment(comment, update_attrs)
-      assert comment.author == "some updated author"
-      assert comment.comment == "some updated comment"
-      assert comment.url == "some updated url"
+    test "create_comment with site requiring approval" do
+      comment_site = insert(:comment_site, requires_approval: true)
     end
+  end
 
-    test "update_comment/2 with invalid data returns error changeset" do
-      comment = insert(:comment)
-      assert {:error, %Ecto.Changeset{}} = Comments.update_comment(comment, @invalid_attrs)
-    end
+  test "update_comment/2 with valid data updates the comment" do
+    comment = insert(:comment)
 
-    test "delete_comment/1 deletes the comment" do
-      comment = insert(:comment)
-      assert {:ok, %Comment{}} = Comments.delete_comment(comment)
-      assert_raise Ecto.NoResultsError, fn -> Comments.get_comment!(comment.id) end
-    end
+    update_attrs = %{
+      author: "some updated author",
+      comment: "some updated comment",
+      url: "some updated url"
+    }
 
-    test "change_comment/1 returns a comment changeset" do
-      comment = insert(:comment)
-      assert %Ecto.Changeset{} = Comments.change_comment(comment)
-    end
+    assert {:ok, %Comment{} = comment} = Comments.update_comment(comment, update_attrs)
+    assert comment.author == "some updated author"
+    assert comment.comment == "some updated comment"
+    assert comment.url == "some updated url"
+  end
+
+  test "update_comment/2 with invalid data returns error changeset" do
+    comment = insert(:comment)
+    assert {:error, %Ecto.Changeset{}} = Comments.update_comment(comment, @invalid_attrs)
+  end
+
+  test "delete_comment/1 deletes the comment" do
+    comment = insert(:comment)
+    assert {:ok, %Comment{}} = Comments.delete_comment(comment)
+    assert_raise Ecto.NoResultsError, fn -> Comments.get_comment!(comment.id) end
+  end
+
+  test "change_comment/1 returns a comment changeset" do
+    comment = insert(:comment)
+    assert %Ecto.Changeset{} = Comments.change_comment(comment)
   end
 end

--- a/test/launch_cart_web/features/launch_comments_test.exs
+++ b/test/launch_cart_web/features/launch_comments_test.exs
@@ -36,6 +36,7 @@ defmodule LaunchCartWeb.Features.LaunchCommentsTest do
     |> visit("/fake_comment_site/#{comment_site.id}")
     |> find(css("launch-comments"))
     |> shadow_root()
+    |> assert_has(css("div", text: "Your comments will appear after approval"))
     |> fill_in(css("#author"), with: "Bob")
     |> fill_in(css("#comment"), with: "Has sumpin to say")
     |> click(css("button"))

--- a/test/launch_cart_web/live/comment_site_live_test.exs
+++ b/test/launch_cart_web/live/comment_site_live_test.exs
@@ -4,6 +4,8 @@ defmodule LaunchCartWeb.CommentSiteLiveTest do
   import Phoenix.LiveViewTest
   import LaunchCart.CommentSitesFixtures
   import LaunchCart.Factory
+  alias LaunchCart.Comments
+  alias LaunchCart.Comments.Comment
 
   @create_attrs %{name: "some name", url: "some url"}
   @update_attrs %{name: "some updated name", url: "some updated url"}
@@ -107,15 +109,29 @@ defmodule LaunchCartWeb.CommentSiteLiveTest do
     #   end
   end
 
-  # describe "Show" do
-  #   setup [:create_comment_site]
+  describe "View Comments" do
+    setup [:create_comment_site]
 
-  #   test "displays comment_site", %{conn: conn, comment_site: comment_site} do
-  #     {:ok, _show_live, html} = live(conn, ~p"/comment_sites/#{comment_site}")
+    test "can approve comments", %{conn: conn, comment_site: comment_site} do
+      comment1 = insert(:comment, comment_site: comment_site, approved: false)
+      comment2 = insert(:comment, comment_site: comment_site, approved: false)
+      {:ok, show_live, html} = live(conn, Routes.comment_site_comments_path(conn, :index, comment_site))
+      assert html =~ comment1.comment
+      assert html =~ comment2.comment
 
-  #     assert html =~ "Show Comment site"
-  #     assert html =~ comment_site.name
-  #   end
+      show_live |> element("#approve-comment-#{comment1.id}") |> render_click()
+
+      assert %Comment{approved: true} = Comments.get_comment!(comment1.id)
+    end
+  end
+  describe "Show" do
+    setup [:create_comment_site]
+
+    test "displays comment_site", %{conn: conn, comment_site: comment_site} do
+      {:ok, _show_live, html} = live(conn, Routes.comment_site_show_path(conn, :show, comment_site))
+
+      assert html =~ comment_site.name
+    end
 
   #   test "updates comment_site within modal", %{conn: conn, comment_site: comment_site} do
   #     {:ok, show_live, _html} = live(conn, ~p"/comment_sites/#{comment_site}")
@@ -139,5 +155,5 @@ defmodule LaunchCartWeb.CommentSiteLiveTest do
   #     assert html =~ "Comment site updated successfully"
   #     assert html =~ "some updated name"
   #   end
-  # end
+  end
 end


### PR DESCRIPTION
By user request, comment sites can optionally require approval. Comments are viewable and approvable from the comment sites show page.